### PR TITLE
Add Python plugin support with nanobind and fix bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ cmake .. -DBUILD_PYTHON_PLUGINS=ON
 make
 ```
 
-This produces the `thunder_core` Python package (nanobind bindings for `Robot` and utilities, plus pure-Python modules for plugin base classes and pipeline execution) and enables the `py:` prefix in YAML pipeline configurations.
+This produces the `thunder_core` Python package (nanobind bindings for `Robot` and utilities, plus pure-Python modules for plugin base classes and pipeline execution) and enables the `py.` prefix in YAML pipeline configurations.
 
 ### `thunder_core` package structure
 
@@ -111,20 +111,20 @@ Everything from `_bindings` is re-exported at the top level, so `thunder_core.Ro
 
 ### Python plugin conventions
 
-Use the `py:module.ClassName` syntax in the pipeline YAML to reference Python plugins:
+Use the `py.module.ClassName` syntax in the pipeline YAML to reference Python plugins:
 
 ```yaml
 pipeline:
   loaders:    ["kin_loader", "dyn_loader"]
-  builders:   ["kin_builder", "dyn_builder", "py:my_plugins.MyBuilder"]
+  builders:   ["kin_builder", "dyn_builder", "py.my_plugins.MyBuilder"]
   generators: ["robot_generator"]
 
-# Config block for the Python plugin (key = full py: name)
-"py:my_plugins.MyBuilder":
+# Config block for the Python plugin (key = full py.module.Class name)
+"py.my_plugins.MyBuilder":
   my_param: 42
 ```
 
-Multiple Python plugins of the same type are supported — just add more `py:` entries.
+Multiple Python plugins of the same type are supported, just add more `py.` entries.
 
 The Python module file (e.g., `my_plugins.py`) should be placed **in the same directory as the YAML config file**. Standard `PYTHONPATH` and `sys.path` rules also apply.
 
@@ -258,7 +258,7 @@ thunder_core.R_z(angle)    # rotation about Z
 - **Shared Robot object**: Python plugins receive the same `Robot` instance as C++ plugins. Modifications (adding functions, setting parameters) persist across the pipeline.
 - **Dynamic attributes**: You can set arbitrary Python attributes on the Robot object (e.g., `robot.my_data = [1,2,3]`). These are visible to subsequent Python plugins but not to C++ plugins. Use `robot.add_property_*()` or `robot.add_parameter()` if C++ needs access.
 - **Error handling**: Python exceptions are caught and re-raised as C++ `std::runtime_error` with the full Python traceback.
-- **Config**: The YAML config block for a Python plugin is passed to `configure()` as a Python dict (or validated via pydantic if `ConfigModel` is defined). The key in the YAML must match the full `py:module.Class` name.
+- **Config**: The YAML config block for a Python plugin is passed to `configure()` as a Python dict (or validated via pydantic if `ConfigModel` is defined). The key in the YAML must match the full `py.module.Class` name.
 
 ### Example
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,187 @@ Done!
 
 ---
 
+## Writing plugins in Python
+
+Thunder supports writing plugins in Python. This requires building with Python plugin support enabled:
+
+```bash
+cd src/thunder
+mkdir -p build && cd build
+cmake .. -DBUILD_PYTHON_PLUGINS=ON
+make
+```
+
+This produces the `thunder_core` Python package (nanobind bindings for `Robot` and utilities, plus pure-Python modules for plugin base classes and pipeline execution) and enables the `py:` prefix in YAML pipeline configurations.
+
+### `thunder_core` package structure
+
+```
+thunder_core                  # Python package
+├── _bindings                 # Compiled C++ nanobind module (Robot, PluginManager, utils)
+├── plugins                   # ABC base classes: BaseLoader, BaseBuilder, BaseGenerator
+└── pipeline                  # Config class and run_pipeline() for pipeline execution
+```
+
+Everything from `_bindings` is re-exported at the top level, so `thunder_core.Robot`, `thunder_core.PluginManager`, etc. work directly.
+
+### Python plugin conventions
+
+Use the `py:module.ClassName` syntax in the pipeline YAML to reference Python plugins:
+
+```yaml
+pipeline:
+  loaders:    ["kin_loader", "dyn_loader"]
+  builders:   ["kin_builder", "dyn_builder", "py:my_plugins.MyBuilder"]
+  generators: ["robot_generator"]
+
+# Config block for the Python plugin (key = full py: name)
+"py:my_plugins.MyBuilder":
+  my_param: 42
+```
+
+Multiple Python plugins of the same type are supported — just add more `py:` entries.
+
+The Python module file (e.g., `my_plugins.py`) should be placed **in the same directory as the YAML config file**. Standard `PYTHONPATH` and `sys.path` rules also apply.
+
+### Writing Python plugins
+
+All Python plugins **must** inherit from the appropriate base class in `thunder_core.plugins`:
+
+| Plugin type | Base class     | Required method      |
+|-------------|----------------|----------------------|
+| Loader      | `BaseLoader`   | `load(self, robot)`  |
+| Builder     | `BaseBuilder`  | `build(self, robot)` |
+| Generator   | `BaseGenerator`| `generate(self, robot)` |
+
+These are abstract classes — forgetting to implement the required method will raise a `TypeError` at instantiation.
+
+#### Minimal builder template
+
+```python
+import casadi
+from thunder_core.plugins import BaseBuilder
+
+class MyBuilder(BaseBuilder):
+    def build(self, robot):
+        q = robot.get_model("q")            # returns casadi.SX
+        expr = casadi.cos(q)                 # standard CasADi Python API
+        robot.add_function("cos_q", expr, ["q"], "Cosine of joint angles")
+```
+
+#### Optional pydantic config validation
+
+Plugins can optionally define a `ConfigModel` class attribute (a pydantic `BaseModel` subclass) to validate the YAML config dict received in `configure()`. When present, `self.config` will be the validated pydantic model instance instead of a raw dict:
+
+```python
+import casadi
+from pydantic import BaseModel
+from thunder_core.plugins import BaseBuilder
+
+class MyBuilder(BaseBuilder):
+    class ConfigModel(BaseModel):
+        function_name: str = "cos_q"
+        scale: float = 1.0
+
+    def build(self, robot):
+        q = robot.get_model("q")
+        robot.add_function(
+            self.config.function_name,
+            self.config.scale * casadi.cos(q),
+            ["q"],
+            "Scaled cosine of joint angles",
+        )
+```
+
+If no `ConfigModel` is defined, `self.config` remains a plain Python dict (backward-compatible).
+
+### Running the pipeline from Python
+
+Use `thunder_core.pipeline` to run a pipeline from Python code or Jupyter notebooks:
+
+```python
+from thunder_core.pipeline import Config, run_pipeline
+
+# Quick one-liner from a YAML file
+robot = run_pipeline("path/to/robot.yaml", robot_name="my_robot")
+
+# Or from a dict
+robot = run_pipeline({
+    "pipeline": {
+        "loaders": ["kin_loader"],
+        "builders": ["kin_builder"],
+        "generators": []
+    },
+    "kin_loader": { "num_joints": 2, "joints_type": ["R", "R"] }
+}, robot_name="RR")
+
+# Or use Config directly for more control
+cfg = Config("path/to/robot.yaml")
+print(cfg)
+robot = cfg.execute(robot_name="RR", verbose=True)
+```
+
+### Available Robot API in Python
+
+```python
+import thunder_core
+
+robot = thunder_core.Robot("my_robot")
+
+# Properties (typed getters/setters — C++ templates mapped to explicit methods)
+robot.add_property_int("ndof", 3)
+robot.add_property_double("mass", 10.5)
+robot.add_property_string("name", "arm")
+robot.add_property_vector_double("lengths", [1.0, 1.0, 1.0])
+ndof  = robot.get_int("ndof")
+name  = robot.get_string("name")
+
+# Symbolic variables and parameters (CasADi SX/DM pass seamlessly)
+q = casadi.SX.sym("q", 3)
+robot.add_variable("q", q, [0.0, 0.0, 0.0], [1, 1, 1])
+
+# Symbolic model access
+q_sym = robot.get_model("q")       # returns casadi.SX
+
+# Numeric evaluation
+q_val = robot.get_value("q")       # returns casadi.DM
+
+# Set parameter values
+robot.set("q", casadi.DM([1.0, 2.0, 3.0]))
+
+# Add symbolic functions
+robot.add_function("sin_q", casadi.sin(q), ["q"], "Sine of q")
+
+# I/O
+robot.save_par("params.yaml")
+robot.load_par("params.yaml")
+
+# Direct map access
+print(robot.properties)    # dict-like: {name: Property, ...}
+print(robot.parameters)    # dict-like: {name: Parameter, ...}
+print(robot.functions)     # dict-like: {name: Function, ...}
+
+# Utility functions
+thunder_core.hat(v)        # skew-symmetric matrix
+thunder_core.R_x(angle)    # rotation about X
+thunder_core.R_y(angle)    # rotation about Y
+thunder_core.R_z(angle)    # rotation about Z
+```
+
+### Notes on Python plugins
+
+- **CasADi interop**: CasADi's Python objects (`casadi.SX`, `casadi.DM`, `casadi.Function`) are converted automatically at the C++/Python boundary using SWIG pointer extraction. No serialization overhead.
+- **Shared Robot object**: Python plugins receive the same `Robot` instance as C++ plugins. Modifications (adding functions, setting parameters) persist across the pipeline.
+- **Dynamic attributes**: You can set arbitrary Python attributes on the Robot object (e.g., `robot.my_data = [1,2,3]`). These are visible to subsequent Python plugins but not to C++ plugins. Use `robot.add_property_*()` or `robot.add_parameter()` if C++ needs access.
+- **Error handling**: Python exceptions are caught and re-raised as C++ `std::runtime_error` with the full Python traceback.
+- **Config**: The YAML config block for a Python plugin is passed to `configure()` as a Python dict (or validated via pydantic if `ConfigModel` is defined). The key in the YAML must match the full `py:module.Class` name.
+
+### Example
+
+See `src/thunder/robots/debug/RRR_py.yaml` and `src/thunder/robots/debug/my_py_builder.py` for a working example.
+
+---
+
 
 
 

--- a/python/thunder_core/__init__.py
+++ b/python/thunder_core/__init__.py
@@ -1,23 +1,42 @@
-# thunder_core: Python interface for Thunder Dynamics
-#
-# Re-exports all C++ bindings from the compiled _bindings module,
-# plus pure-Python submodules: plugins, pipeline.
-from thunder_core._bindings import (
-    Property,
-    Parameter,
-    FunArg,
-    Function,
-    Robot,
-    PluginManager,
-    hat,
-    vect,
-    R_x,
-    R_y,
-    R_z,
-    R_aa,
-    get_transform_rpy,
-    get_euler_rpy,
-)
+"""thunder_core: Python interface for Thunder Dynamics."""
+
+try:
+    from thunder_core._bindings import (
+        Property,
+        Parameter,
+        FunArg,
+        Function,
+        Robot,
+        PluginManager,
+        hat,
+        vect,
+        R_x,
+        R_y,
+        R_z,
+        R_aa,
+        get_transform_rpy,
+        get_euler_rpy,
+    )
+except ModuleNotFoundError as exc:
+    if exc.name != "thunder_core._bindings":
+        raise
+
+    from _bindings import (
+        Property,
+        Parameter,
+        FunArg,
+        Function,
+        Robot,
+        PluginManager,
+        hat,
+        vect,
+        R_x,
+        R_y,
+        R_z,
+        R_aa,
+        get_transform_rpy,
+        get_euler_rpy,
+    )
 
 from thunder_core import plugins, pipeline
 

--- a/python/thunder_core/__init__.py
+++ b/python/thunder_core/__init__.py
@@ -1,0 +1,43 @@
+# thunder_core: Python interface for Thunder Dynamics
+#
+# Re-exports all C++ bindings from the compiled _bindings module,
+# plus pure-Python submodules: plugins, pipeline.
+from thunder_core._bindings import (
+    Property,
+    Parameter,
+    FunArg,
+    Function,
+    Robot,
+    PluginManager,
+    hat,
+    vect,
+    R_x,
+    R_y,
+    R_z,
+    R_aa,
+    get_transform_rpy,
+    get_euler_rpy,
+)
+
+from thunder_core import plugins, pipeline
+
+__all__ = [
+    # C++ bindings
+    "Property",
+    "Parameter",
+    "FunArg",
+    "Function",
+    "Robot",
+    "PluginManager",
+    "hat",
+    "vect",
+    "R_x",
+    "R_y",
+    "R_z",
+    "R_aa",
+    "get_transform_rpy",
+    "get_euler_rpy",
+    # Submodules
+    "plugins",
+    "pipeline",
+]

--- a/python/thunder_core/pipeline.py
+++ b/python/thunder_core/pipeline.py
@@ -1,0 +1,113 @@
+"""
+Thunder pipeline configuration and execution from Python.
+
+Allows running the full Thunder plugin pipeline from Python code or notebooks,
+using either a YAML file or a Python dict as configuration.
+
+Example::
+
+    from thunder_core.pipeline import Config, run_pipeline
+
+    # From YAML file
+    robot = run_pipeline("path/to/robot.yaml", robot_name="my_robot")
+
+    # From dict
+    robot = run_pipeline({
+        "pipeline": {
+            "loaders": ["kin_loader"],
+            "builders": ["kin_builder"],
+            "generators": []
+        },
+        "kin_loader": {
+            "num_joints": 2,
+            "joints_type": ["R", "R"],
+        }
+    }, robot_name="RR")
+
+    # Or use Config directly for more control
+    cfg = Config("path/to/robot.yaml")
+    print(cfg)
+    robot = cfg.execute(robot_name="RR")
+"""
+
+import os
+import tempfile
+
+import yaml
+import thunder_core
+
+
+class Config:
+    """Thunder pipeline configuration.
+
+    Can be created from a YAML file path or a Python dict.
+    Handles conversion to a temporary YAML file for the C++ PluginManager.
+
+    Args:
+        config: Either a file path (str) to a YAML file, or a dict with
+                the pipeline configuration.
+    """
+
+    def __init__(self, config):
+        if isinstance(config, str):
+            self.yaml_path = os.path.abspath(config)
+            with open(self.yaml_path) as f:
+                self.data = yaml.safe_load(f)
+            self._temp_file = None
+        elif isinstance(config, dict):
+            self.data = config
+            self.yaml_path = None
+            self._temp_file = None
+        else:
+            raise TypeError(f"Config expects str (file path) or dict, got {type(config).__name__}")
+
+    def _ensure_yaml_file(self):
+        """Create a temporary YAML file from dict config if needed."""
+        if self.yaml_path is not None:
+            return self.yaml_path
+
+        if self._temp_file is None:
+            self._temp_file = tempfile.NamedTemporaryFile(
+                mode='w', suffix='.yaml', delete=False, prefix='thunder_'
+            )
+            yaml.dump(self.data, self._temp_file, default_flow_style=False)
+            self._temp_file.close()
+            self.yaml_path = self._temp_file.name
+
+        return self.yaml_path
+
+    def execute(self, robot_name="robot", no_generation=True, verbose=False):
+        """Run the pipeline and return the Robot.
+
+        Args:
+            robot_name: Name for the robot instance.
+            no_generation: If True (default), skip generator plugins.
+                Useful for interactive/notebook use where you don't want
+                code generation, just the symbolic model.
+            verbose: Print pipeline progress.
+
+        Returns:
+            thunder_core.Robot with all loaded data, parameters, and functions.
+        """
+        pm = thunder_core.PluginManager()
+        pm.set_verbose(verbose)
+        pm.configure_pipeline(self._ensure_yaml_file(), int(no_generation))
+        return pm.execute(robot_name)
+
+    def __del__(self):
+        """Clean up temporary YAML file."""
+        if self._temp_file is not None:
+            try:
+                os.unlink(self._temp_file.name)
+            except OSError:
+                pass
+
+    def __repr__(self):
+        src = self.yaml_path or "dict"
+        plugins = self.data.get("pipeline", {})
+        return (
+            f"Config({src}, "
+            f"loaders={plugins.get('loaders', [])}, "
+            f"builders={plugins.get('builders', [])}, "
+            f"generators={plugins.get('generators', [])})"
+        )

--- a/python/thunder_core/pipeline.py
+++ b/python/thunder_core/pipeline.py
@@ -70,7 +70,10 @@ class Config:
             self._temp_file = tempfile.NamedTemporaryFile(
                 mode='w', suffix='.yaml', delete=False, prefix='thunder_'
             )
-            yaml.dump(self.data, self._temp_file, default_flow_style=False)
+            # Order of elements in params is significant to loaders such as kin_loader.
+            # PyYAML sorts mappings by default, which differs from the dict.
+            # This is a problem when a configuration is supplied as a Python dict, so we disable sorting here.
+            yaml.dump(self.data, self._temp_file, default_flow_style=False, sort_keys=False)
             self._temp_file.close()
             self.yaml_path = self._temp_file.name
 

--- a/python/thunder_core/plugins.py
+++ b/python/thunder_core/plugins.py
@@ -1,0 +1,107 @@
+"""
+Base classes for Thunder Python plugins.
+
+All Python plugins MUST inherit from the appropriate base class
+(BaseLoader, BaseBuilder, or BaseGenerator). These are abstract —
+you must implement the required methods.
+
+Plugins can optionally define a ``ConfigModel`` class attribute
+(a pydantic BaseModel subclass) to validate the YAML config dict
+received in ``configure()``. When present, ``self.config`` will be
+the validated pydantic model instance instead of a raw dict.
+
+Example::
+
+    from pydantic import BaseModel
+    from thunder_core.plugins import BaseBuilder
+
+    class MyBuilder(BaseBuilder):
+        class ConfigModel(BaseModel):
+            function_name: str = "cos_q"
+            scale: float = 1.0
+
+        def build(self, robot):
+            # self.config is a validated ConfigModel instance
+            q = robot.get_model("q")
+            import casadi
+            robot.add_function(
+                self.config.function_name,
+                self.config.scale * casadi.cos(q),
+                ["q"],
+            )
+"""
+
+from abc import ABC, abstractmethod
+
+
+class _PluginBase(ABC):
+    """Common base for all Thunder plugin types.
+
+    Handles optional pydantic config validation via the ``ConfigModel``
+    class attribute.
+    """
+
+    ConfigModel = None  # Override with a pydantic BaseModel subclass
+
+    def configure(self, config: dict) -> None:
+        """Called with the plugin's YAML config section as a Python dict.
+
+        If the plugin defines a ``ConfigModel`` (pydantic BaseModel),
+        the dict is validated and ``self.config`` is set to the model
+        instance. Otherwise ``self.config`` is the raw dict.
+        """
+        if self.ConfigModel is not None:
+            self.config = self.ConfigModel(**config)
+        else:
+            self.config = config
+
+
+class BaseLoader(_PluginBase):
+    """Base class for Python loader plugins.
+
+    Loaders initialize the Robot with properties and parameters
+    from configuration data (URDF, DH tables, custom formats, etc.).
+    """
+
+    @abstractmethod
+    def load(self, robot) -> None:
+        """Populate the robot with initial data.
+
+        Args:
+            robot: thunder_core.Robot instance (shared with C++ pipeline)
+        """
+        ...
+
+
+class BaseBuilder(_PluginBase):
+    """Base class for Python builder plugins.
+
+    Builders perform symbolic computation (e.g. kinematics, dynamics)
+    and add functions to the Robot using CasADi expressions.
+    """
+
+    @abstractmethod
+    def build(self, robot) -> None:
+        """Build symbolic functions on the robot.
+
+        Args:
+            robot: thunder_core.Robot instance (shared with C++ pipeline)
+        """
+        ...
+
+
+class BaseGenerator(_PluginBase):
+    """Base class for Python generator plugins.
+
+    Generators read the completed Robot model and produce output
+    (code files, visualizations, exports, etc.).
+    """
+
+    @abstractmethod
+    def generate(self, robot) -> None:
+        """Generate output from the robot model.
+
+        Args:
+            robot: thunder_core.Robot instance (read-only recommended)
+        """
+        ...

--- a/src/thunder/CMakeLists.txt
+++ b/src/thunder/CMakeLists.txt
@@ -128,9 +128,11 @@ install(DIRECTORY ${CMAKE_SOURCE_DIR}/data/templates DESTINATION ${CMAKE_INSTALL
 # =============================== #
 # --- Python Plugin Support  --- #
 # =============================== #
-option(BUILD_PYTHON_PLUGINS "Build Python plugin support with nanobind" OFF)
+
+option(BUILD_PYTHON_PLUGINS "Build Python plugin support with nanobind" ON)
 
 if(BUILD_PYTHON_PLUGINS)
+  message(STATUS "Configuring Python plugin support...")
   find_package(Python 3.8 COMPONENTS Interpreter Development REQUIRED)
   find_package(SWIG REQUIRED)
   include(${SWIG_USE_FILE})
@@ -189,6 +191,9 @@ if(BUILD_PYTHON_PLUGINS)
 
   # Install thunder_core Python package (pure-Python parts)
   install(DIRECTORY ${CMAKE_SOURCE_DIR}/../../python/thunder_core
+    DESTINATION ${PYTHON_SITE_PACKAGES})
+  # Install thunder_plugins package (Python plugin system)
+  install(DIRECTORY ${CMAKE_SOURCE_DIR}/../../python/thunder_plugins
     DESTINATION ${PYTHON_SITE_PACKAGES})
 
   message(STATUS "Python plugin support ENABLED")

--- a/src/thunder/CMakeLists.txt
+++ b/src/thunder/CMakeLists.txt
@@ -1,5 +1,5 @@
 # cmake and c++ version
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.18)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
@@ -17,21 +17,18 @@ set (CMAKE_CXX_FLAGS "-g3 -lstdc++fs -std=c++17")
 include_directories(${CMAKE_SOURCE_DIR}/include)
 
 # Add all source files in the "src" directory to the SOURCES variable
-file(GLOB_RECURSE SOURCES 
+file(GLOB_RECURSE SOURCES
   ${CMAKE_SOURCE_DIR}/src/*.cpp
-  # ${CMAKE_SOURCE_DIR}/src/plugins/*.cpp
-  # ${CMAKE_SOURCE_DIR}/src/plugins/loaders/*.cpp
-  # ${CMAKE_SOURCE_DIR}/src/plugins/builders/*.cpp
-  # ${CMAKE_SOURCE_DIR}/src/plugins/builders/common/*.cpp
-  # ${CMAKE_SOURCE_DIR}/src/plugins/generators/*.cpp
-  # ${CMAKE_SOURCE_DIR}/src/plugins/generators/common/*.cpp
 )
+# Exclude Python proxy 
+list(FILTER SOURCES EXCLUDE REGEX ".*/plugins/python/.*")
 
 # Define the library target with the collected source files
 add_library(library ${SOURCES})
 
 # Set the output name for the library
 set_target_properties(library PROPERTIES OUTPUT_NAME "library")
+set_target_properties(library PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 # Make the library's headers available to other projects
 target_include_directories(library PUBLIC ${CMAKE_SOURCE_DIR}/include)
@@ -127,3 +124,75 @@ set(CMAKE_INSTALL_PREFIX "/usr/local" CACHE PATH "default install path" FORCE)
 # Install the executable and the template directory
 install(TARGETS thunder RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/data/templates DESTINATION ${CMAKE_INSTALL_PREFIX}/share/thunder_dynamics)
+
+# =============================== #
+# --- Python Plugin Support  --- #
+# =============================== #
+option(BUILD_PYTHON_PLUGINS "Build Python plugin support with nanobind" OFF)
+
+if(BUILD_PYTHON_PLUGINS)
+  find_package(Python 3.8 COMPONENTS Interpreter Development REQUIRED)
+  find_package(SWIG REQUIRED)
+  include(${SWIG_USE_FILE})
+
+  # Generate swigpyrun.h (SWIG runtime header for pointer extraction)
+  set(SWIGPYRUN_DIR "${CMAKE_CURRENT_BINARY_DIR}/swigpyrun")
+  set(SWIGPYRUN_OUTPUT "${SWIGPYRUN_DIR}/swigpyrun.h")
+  file(MAKE_DIRECTORY ${SWIGPYRUN_DIR})
+  add_custom_command(
+    OUTPUT ${SWIGPYRUN_OUTPUT}
+    COMMAND ${SWIG_EXECUTABLE} -python -external-runtime ${SWIGPYRUN_OUTPUT}
+    COMMENT "Generating swigpyrun.h for CasADi type bridge"
+    VERBATIM
+  )
+  add_custom_target(generate_swigpyrun ALL DEPENDS ${SWIGPYRUN_OUTPUT})
+
+  # Fetch nanobind
+  FetchContent_Declare(
+    nanobind
+    GIT_REPOSITORY https://github.com/wjakob/nanobind.git
+    GIT_TAG v2.4.0
+  )
+  FetchContent_MakeAvailable(nanobind)
+
+  # thunder_core._bindings Python module (Robot bindings + CasADi type casters)
+  nanobind_add_module(_bindings
+    ${CMAKE_SOURCE_DIR}/python/bindings.cpp
+  )
+  target_link_libraries(_bindings PRIVATE library)
+  target_include_directories(_bindings PRIVATE
+    ${CMAKE_SOURCE_DIR}/python
+    ${SWIGPYRUN_DIR}
+  )
+  add_dependencies(_bindings generate_swigpyrun)
+
+  # Add Python proxy plugin sources to the main library
+  target_sources(library PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/plugins/python/py_plugin_proxy.cpp
+  )
+  target_link_libraries(library Python::Python)
+  target_include_directories(library PRIVATE ${SWIGPYRUN_DIR})
+  target_compile_definitions(library PUBLIC THUNDER_PYTHON_PLUGINS)
+  add_dependencies(library generate_swigpyrun)
+
+  # Also give the thunder executable nanobind/Python include paths
+  target_include_directories(thunder PRIVATE ${SWIGPYRUN_DIR})
+
+  # Install thunder_core package to Python site-packages
+  execute_process(
+    COMMAND ${Python_EXECUTABLE} -c "import sysconfig; print(sysconfig.get_path('purelib'))"
+    OUTPUT_VARIABLE PYTHON_SITE_PACKAGES
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  # Install compiled _bindings module into thunder_core package directory
+  install(TARGETS _bindings LIBRARY DESTINATION ${PYTHON_SITE_PACKAGES}/thunder_core)
+
+  # Install thunder_core Python package (pure-Python parts)
+  install(DIRECTORY ${CMAKE_SOURCE_DIR}/../../python/thunder_core
+    DESTINATION ${PYTHON_SITE_PACKAGES})
+
+  message(STATUS "Python plugin support ENABLED")
+  message(STATUS "  Python: ${Python_EXECUTABLE} (${Python_VERSION})")
+  message(STATUS "  SWIG:   ${SWIG_EXECUTABLE} (${SWIG_VERSION})")
+  message(STATUS "  Install to: ${PYTHON_SITE_PACKAGES}")
+endif()

--- a/src/thunder/CMakeLists.txt
+++ b/src/thunder/CMakeLists.txt
@@ -130,6 +130,8 @@ install(DIRECTORY ${CMAKE_SOURCE_DIR}/data/templates DESTINATION ${CMAKE_INSTALL
 # =============================== #
 
 option(BUILD_PYTHON_PLUGINS "Build Python plugin support with nanobind" ON)
+option(THUNDER_USE_LOCAL_PYTHON_FILES "Use local thunder_core/thunder_plugins sources instead of installing Python packages" OFF)
+set(THUNDER_LOCAL_PYTHON_ROOT "${CMAKE_SOURCE_DIR}/../../python" CACHE PATH "Path to local Python source root (must contain thunder_core and thunder_plugins)")
 
 if(BUILD_PYTHON_PLUGINS)
   message(STATUS "Configuring Python plugin support...")
@@ -161,6 +163,13 @@ if(BUILD_PYTHON_PLUGINS)
   nanobind_add_module(_bindings
     ${CMAKE_SOURCE_DIR}/python/bindings.cpp
   )
+
+  if(THUNDER_USE_LOCAL_PYTHON_FILES)
+    #  write compiled module next to local thunder_core package.
+    set_target_properties(_bindings PROPERTIES
+      LIBRARY_OUTPUT_DIRECTORY "${THUNDER_LOCAL_PYTHON_ROOT}/thunder_core")
+  endif()
+
   target_link_libraries(_bindings PRIVATE library)
   target_include_directories(_bindings PRIVATE
     ${CMAKE_SOURCE_DIR}/python
@@ -186,15 +195,22 @@ if(BUILD_PYTHON_PLUGINS)
     OUTPUT_VARIABLE PYTHON_SITE_PACKAGES
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
-  # Install compiled _bindings module into thunder_core package directory
-  install(TARGETS _bindings LIBRARY DESTINATION ${PYTHON_SITE_PACKAGES}/thunder_core)
 
-  # Install thunder_core Python package (pure-Python parts)
-  install(DIRECTORY ${CMAKE_SOURCE_DIR}/../../python/thunder_core
-    DESTINATION ${PYTHON_SITE_PACKAGES})
-  # Install thunder_plugins package (Python plugin system)
-  install(DIRECTORY ${CMAKE_SOURCE_DIR}/../../python/thunder_plugins
-    DESTINATION ${PYTHON_SITE_PACKAGES})
+  if(THUNDER_USE_LOCAL_PYTHON_FILES)
+    message(STATUS "  Local Python source mode ENABLED")
+    message(STATUS "  Local root: ${THUNDER_LOCAL_PYTHON_ROOT}")
+    message(STATUS "  _bindings output: ${THUNDER_LOCAL_PYTHON_ROOT}/thunder_core")
+    message(STATUS "  Skipping install of thunder_core/thunder_plugins into site-packages")
+  else()
+    # Install compiled _bindings module into thunder_core package directory
+    install(TARGETS _bindings LIBRARY DESTINATION ${PYTHON_SITE_PACKAGES}/thunder_core)
+    # Install thunder_core Python package (pure-Python parts)
+    install(DIRECTORY ${CMAKE_SOURCE_DIR}/../../python/thunder_core
+      DESTINATION ${PYTHON_SITE_PACKAGES})
+    # Install thunder_plugins package (Python plugin system)
+    install(DIRECTORY ${CMAKE_SOURCE_DIR}/../../python/thunder_plugins
+      DESTINATION ${PYTHON_SITE_PACKAGES})
+  endif()
 
   message(STATUS "Python plugin support ENABLED")
   message(STATUS "  Python: ${Python_EXECUTABLE} (${Python_VERSION})")

--- a/src/thunder/include/plugin_manager.h
+++ b/src/thunder/include/plugin_manager.h
@@ -150,7 +150,7 @@ namespace thunder_ns {
 			for (const auto &name : loader_names) {
 				std::shared_ptr<BaseLoader> plugin;
 #ifdef THUNDER_PYTHON_PLUGINS
-				if (name.size() > 3 && name.substr(0, 3) == "py:") {
+				if (name.size() > 3 && name.substr(0, 3) == "PY.") {
 					auto [mod, cls] = parse_py_plugin_name(name);
 					plugin = std::make_shared<PyLoaderProxy>(mod, cls);
 				} else
@@ -169,7 +169,7 @@ namespace thunder_ns {
 			for (const auto &name : builder_names) {
 				std::shared_ptr<BaseBuilder> plugin;
 #ifdef THUNDER_PYTHON_PLUGINS
-				if (name.size() > 3 && name.substr(0, 3) == "py:") {
+				if (name.size() > 3 && name.substr(0, 3) == "PY.") {
 					auto [mod, cls] = parse_py_plugin_name(name);
 					plugin = std::make_shared<PyBuilderProxy>(mod, cls);
 				} else
@@ -188,7 +188,7 @@ namespace thunder_ns {
 			for (const auto &name : generator_names) {
 				std::shared_ptr<BaseGenerator> plugin;
 #ifdef THUNDER_PYTHON_PLUGINS
-				if (name.size() > 3 && name.substr(0, 3) == "py:") {
+				if (name.size() > 3 && name.substr(0, 3) == "PY.") {
 					auto [mod, cls] = parse_py_plugin_name(name);
 					plugin = std::make_shared<PyGeneratorProxy>(mod, cls);
 				} else

--- a/src/thunder/include/plugin_manager.h
+++ b/src/thunder/include/plugin_manager.h
@@ -150,7 +150,7 @@ namespace thunder_ns {
 			for (const auto &name : loader_names) {
 				std::shared_ptr<BaseLoader> plugin;
 #ifdef THUNDER_PYTHON_PLUGINS
-				if (name.size() > 3 && name.substr(0, 3) == "PY.") {
+				if (name.size() > 3 && name.substr(0, 3) == "py.") {
 					auto [mod, cls] = parse_py_plugin_name(name);
 					plugin = std::make_shared<PyLoaderProxy>(mod, cls);
 				} else
@@ -169,7 +169,7 @@ namespace thunder_ns {
 			for (const auto &name : builder_names) {
 				std::shared_ptr<BaseBuilder> plugin;
 #ifdef THUNDER_PYTHON_PLUGINS
-				if (name.size() > 3 && name.substr(0, 3) == "PY.") {
+				if (name.size() > 3 && name.substr(0, 3) == "py.") {
 					auto [mod, cls] = parse_py_plugin_name(name);
 					plugin = std::make_shared<PyBuilderProxy>(mod, cls);
 				} else
@@ -188,7 +188,7 @@ namespace thunder_ns {
 			for (const auto &name : generator_names) {
 				std::shared_ptr<BaseGenerator> plugin;
 #ifdef THUNDER_PYTHON_PLUGINS
-				if (name.size() > 3 && name.substr(0, 3) == "PY.") {
+				if (name.size() > 3 && name.substr(0, 3) == "py.") {
 					auto [mod, cls] = parse_py_plugin_name(name);
 					plugin = std::make_shared<PyGeneratorProxy>(mod, cls);
 				} else

--- a/src/thunder/include/plugin_manager.h
+++ b/src/thunder/include/plugin_manager.h
@@ -9,6 +9,10 @@
 #include "plugin_interfaces.h"
 #include "plugin_registry.h"
 
+#ifdef THUNDER_PYTHON_PLUGINS
+#include "plugins/python/py_plugin_proxy.h"
+#endif
+
 namespace thunder_ns {
 
 	class PluginManager {
@@ -144,7 +148,16 @@ namespace thunder_ns {
 			all_plugins.insert(all_plugins.end(), generator_names.begin(), generator_names.end());
 
 			for (const auto &name : loader_names) {
-				auto plugin = find_loader(name);
+				std::shared_ptr<BaseLoader> plugin;
+#ifdef THUNDER_PYTHON_PLUGINS
+				if (name.size() > 3 && name.substr(0, 3) == "py:") {
+					auto [mod, cls] = parse_py_plugin_name(name);
+					plugin = std::make_shared<PyLoaderProxy>(mod, cls);
+				} else
+#endif
+				{
+					plugin = find_loader(name);
+				}
 				if (!plugin)
 					throw std::runtime_error("Loader not found: " + name);
 
@@ -154,7 +167,16 @@ namespace thunder_ns {
 			}
 
 			for (const auto &name : builder_names) {
-				auto plugin = find_builder(name);
+				std::shared_ptr<BaseBuilder> plugin;
+#ifdef THUNDER_PYTHON_PLUGINS
+				if (name.size() > 3 && name.substr(0, 3) == "py:") {
+					auto [mod, cls] = parse_py_plugin_name(name);
+					plugin = std::make_shared<PyBuilderProxy>(mod, cls);
+				} else
+#endif
+				{
+					plugin = find_builder(name);
+				}
 				if (!plugin)
 					throw std::runtime_error("Builder not found: " + name);
 
@@ -164,7 +186,16 @@ namespace thunder_ns {
 			}
 
 			for (const auto &name : generator_names) {
-				auto plugin = find_generator(name);
+				std::shared_ptr<BaseGenerator> plugin;
+#ifdef THUNDER_PYTHON_PLUGINS
+				if (name.size() > 3 && name.substr(0, 3) == "py:") {
+					auto [mod, cls] = parse_py_plugin_name(name);
+					plugin = std::make_shared<PyGeneratorProxy>(mod, cls);
+				} else
+#endif
+				{
+					plugin = find_generator(name);
+				}
 				if (!plugin)
 					throw std::runtime_error("Generator not found: " + name);
 

--- a/src/thunder/include/plugins/python/py_interpreter.h
+++ b/src/thunder/include/plugins/python/py_interpreter.h
@@ -1,0 +1,80 @@
+#ifndef THUNDER_PY_INTERPRETER_H
+#define THUNDER_PY_INTERPRETER_H
+
+#ifdef THUNDER_PYTHON_PLUGINS
+
+#include <Python.h>
+#include <iostream>
+#include <string>
+
+namespace thunder_ns {
+
+/// Singleton managing the embedded Python interpreter lifecycle.
+/// Lazily initializes on first use and finalizes at program exit.
+///
+/// After initialization, the GIL is released so that PyGILState_Ensure/Release
+/// can be used by proxy plugins to acquire it when needed.
+class PythonInterpreter {
+public:
+    static PythonInterpreter& instance() {
+        static PythonInterpreter inst;
+        return inst;
+    }
+
+    /// Ensure the Python interpreter is initialized.
+    /// After first call, the GIL is released (saved as tstate_) so that
+    /// subsequent PyGILState_Ensure() calls work correctly.
+    /// Safe to call multiple times.
+    void ensure_initialized() {
+        if (!initialized_by_us_ && !Py_IsInitialized()) {
+            Py_Initialize();
+            // Enable threading support and release the GIL so that
+            // PyGILState_Ensure/Release work properly from any thread.
+            tstate_ = PyEval_SaveThread();
+            initialized_by_us_ = true;
+        }
+    }
+
+    /// Add a directory to sys.path.
+    /// Must be called after ensure_initialized().
+    /// Acquires and releases the GIL internally.
+    void add_to_sys_path(const std::string& path) {
+        PyGILState_STATE gstate = PyGILState_Ensure();
+
+        PyObject* sys_path = PySys_GetObject("path");
+        if (sys_path) {
+            PyObject* py_path = PyUnicode_FromString(path.c_str());
+            if (!PySequence_Contains(sys_path, py_path)) {
+                PyList_Insert(sys_path, 0, py_path);
+            }
+            Py_DECREF(py_path);
+        }
+
+        PyGILState_Release(gstate);
+    }
+
+    bool is_initialized() const { return Py_IsInitialized(); }
+
+private:
+    PythonInterpreter() = default;
+    ~PythonInterpreter() {
+        if (initialized_by_us_ && Py_IsInitialized()) {
+            // Re-acquire the GIL before finalizing
+            if (tstate_) {
+                PyEval_RestoreThread(tstate_);
+            }
+            Py_FinalizeEx();
+        }
+    }
+
+    PythonInterpreter(const PythonInterpreter&) = delete;
+    PythonInterpreter& operator=(const PythonInterpreter&) = delete;
+
+    bool initialized_by_us_ = false;
+    PyThreadState* tstate_ = nullptr;
+};
+
+} // namespace thunder_ns
+
+#endif // THUNDER_PYTHON_PLUGINS
+#endif // THUNDER_PY_INTERPRETER_H

--- a/src/thunder/include/plugins/python/py_plugin_proxy.h
+++ b/src/thunder/include/plugins/python/py_plugin_proxy.h
@@ -1,0 +1,74 @@
+#ifndef THUNDER_PY_PLUGIN_PROXY_H
+#define THUNDER_PY_PLUGIN_PROXY_H
+
+#ifdef THUNDER_PYTHON_PLUGINS
+
+#include <Python.h>
+#include <string>
+#include <memory>
+#include <tuple>
+
+#include "../../plugin_interfaces.h"
+#include "py_interpreter.h"
+
+namespace thunder_ns {
+
+/// Parse a "py:module.ClassName" string into (module_name, class_name).
+/// Handles dotted module paths: "py:my_pkg.sub.MyClass" -> ("my_pkg.sub", "MyClass")
+std::tuple<std::string, std::string> parse_py_plugin_name(const std::string& name);
+
+// =========================================================================
+// PyLoaderProxy
+// =========================================================================
+class PyLoaderProxy : public BaseLoader {
+public:
+    PyLoaderProxy(const std::string& module_name, const std::string& class_name);
+
+    std::shared_ptr<Robot> load(std::shared_ptr<Robot> robot) override;
+
+private:
+    std::string module_name_;
+    std::string class_name_;
+    PyObject* py_instance_ = nullptr;
+
+    void ensure_instance();
+};
+
+// =========================================================================
+// PyBuilderProxy
+// =========================================================================
+class PyBuilderProxy : public BaseBuilder {
+public:
+    PyBuilderProxy(const std::string& module_name, const std::string& class_name);
+
+    void build(std::shared_ptr<Robot> robot) override;
+
+private:
+    std::string module_name_;
+    std::string class_name_;
+    PyObject* py_instance_ = nullptr;
+
+    void ensure_instance();
+};
+
+// =========================================================================
+// PyGeneratorProxy
+// =========================================================================
+class PyGeneratorProxy : public BaseGenerator {
+public:
+    PyGeneratorProxy(const std::string& module_name, const std::string& class_name);
+
+    void generate(const std::shared_ptr<Robot> robot) override;
+
+private:
+    std::string module_name_;
+    std::string class_name_;
+    PyObject* py_instance_ = nullptr;
+
+    void ensure_instance();
+};
+
+} // namespace thunder_ns
+
+#endif // THUNDER_PYTHON_PLUGINS
+#endif // THUNDER_PY_PLUGIN_PROXY_H

--- a/src/thunder/python/bindings.cpp
+++ b/src/thunder/python/bindings.cpp
@@ -95,6 +95,7 @@ NB_MODULE(_bindings, m) {
         .def_rw("name", &Function::name)
         .def_rw("description", &Function::description)
         .def_rw("args", &Function::args)
+        .def_rw("explicit_args", &Function::explicit_args)
         .def_rw("expr", &Function::expr)
         .def_rw("fun", &Function::fun)
         .def("get_out_size", &Function::get_out_size)

--- a/src/thunder/python/bindings.cpp
+++ b/src/thunder/python/bindings.cpp
@@ -21,7 +21,7 @@
 namespace nb = nanobind;
 using namespace thunder_ns;
 
-NB_MODULE(thunder_core, m) {
+NB_MODULE(_bindings, m) {
     m.doc() = "Thunder Dynamics core bindings — Robot, parameters, functions, and utilities";
 
     // =======================================================================

--- a/src/thunder/python/bindings.cpp
+++ b/src/thunder/python/bindings.cpp
@@ -1,0 +1,245 @@
+// thunder_core: nanobind Python module exposing Robot and core types
+//
+// This module allows Python plugins to interact with the Thunder pipeline
+// by reading/writing Robot properties, parameters, and functions using
+// CasADi symbolic types seamlessly.
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
+#include <nanobind/stl/shared_ptr.h>
+#include <nanobind/stl/map.h>
+
+// Type casters (must be included before any binding code that uses these types)
+#include "casadi_casters.h"
+#include "yaml_casters.h"
+
+#include "robot.h"
+#include "utils.h"
+#include "plugin_manager.h"
+
+namespace nb = nanobind;
+using namespace thunder_ns;
+
+NB_MODULE(thunder_core, m) {
+    m.doc() = "Thunder Dynamics core bindings — Robot, parameters, functions, and utilities";
+
+    // =======================================================================
+    // Property
+    // =======================================================================
+    nb::class_<Property>(m, "Property")
+        .def(nb::init<>())
+        .def_rw("name", &Property::name)
+        .def_rw("description", &Property::description)
+        .def_rw("type_str", &Property::type_str)
+        // std::any cannot be directly exposed; provide a dispatcher
+        .def("get_value", [](const Property& self) -> nb::object {
+            const std::string& t = self.type_str;
+            try {
+                if (t == "int") return nb::cast(std::any_cast<int>(self.value));
+                if (t == "short") return nb::cast(std::any_cast<short>(self.value));
+                if (t == "long") return nb::cast(std::any_cast<long>(self.value));
+                if (t == "float") return nb::cast(std::any_cast<float>(self.value));
+                if (t == "double") return nb::cast(std::any_cast<double>(self.value));
+                if (t == "bool") return nb::cast(std::any_cast<bool>(self.value));
+                if (t == "string" || t == "std::string") return nb::cast(std::any_cast<std::string>(self.value));
+                if (t == "vector<int>") return nb::cast(std::any_cast<std::vector<int>>(self.value));
+                if (t == "vector<double>") return nb::cast(std::any_cast<std::vector<double>>(self.value));
+                if (t == "vector<string>" || t == "vector<std::string>") return nb::cast(std::any_cast<std::vector<std::string>>(self.value));
+                if (t == "vector<short>") return nb::cast(std::any_cast<std::vector<short>>(self.value));
+                if (t == "vector<vector<int>>") return nb::cast(std::any_cast<std::vector<std::vector<int>>>(self.value));
+                if (t == "vector<vector<double>>") return nb::cast(std::any_cast<std::vector<std::vector<double>>>(self.value));
+                if (t == "vector<vector<string>>") return nb::cast(std::any_cast<std::vector<std::vector<std::string>>>(self.value));
+            } catch (const std::bad_any_cast&) {
+                return nb::none();
+            }
+            // Fallback: return string representation
+            return nb::cast(const_cast<Property&>(self).get_value_str());
+        }, "Get property value as a Python object (dispatches on type_str)")
+        .def("get_value_str", static_cast<std::string (Property::*)()>(&Property::get_value_str))
+    ;
+
+    // =======================================================================
+    // Parameter
+    // =======================================================================
+    nb::class_<Parameter>(m, "Parameter")
+        .def(nb::init<>())
+        .def_rw("name", &Parameter::name)
+        .def_rw("description", &Parameter::description)
+        .def_rw("is_symbolic", &Parameter::is_symbolic)
+        .def_rw("symb", &Parameter::symb)
+        .def_rw("num", &Parameter::num)
+        .def("size", &Parameter::size)
+        .def("symb_size", &Parameter::symb_size)
+        .def("get_value_resized", &Parameter::get_value_resized)
+        .def("get_symb_resized", &Parameter::get_symb_resized)
+        .def("get_model", &Parameter::get_model)
+        .def("get_value_str", &Parameter::get_value_str)
+    ;
+
+    // =======================================================================
+    // FunArg
+    // =======================================================================
+    nb::class_<FunArg>(m, "FunArg")
+        .def(nb::init<std::string, casadi::SX>(), nb::arg("name"), nb::arg("value"))
+        .def_rw("name", &FunArg::name)
+        .def_rw("value", &FunArg::value)
+        .def("size", &FunArg::size)
+    ;
+
+    // =======================================================================
+    // Function
+    // =======================================================================
+    nb::class_<Function>(m, "Function")
+        .def(nb::init<>())
+        .def_rw("name", &Function::name)
+        .def_rw("description", &Function::description)
+        .def_rw("args", &Function::args)
+        .def_rw("expr", &Function::expr)
+        .def_rw("fun", &Function::fun)
+        .def("get_out_size", &Function::get_out_size)
+        .def("get_args_str", &Function::get_args_str)
+        .def("get_ret_type_str", &Function::get_ret_type_str)
+    ;
+
+    // =======================================================================
+    // Robot
+    // =======================================================================
+    nb::class_<Robot>(m, "Robot", nb::dynamic_attr())
+        .def(nb::init<std::string>(), nb::arg("name") = "robot")
+        .def(nb::init<>())
+        .def_rw("robotName", &Robot::robotName)
+        .def_rw("properties", &Robot::properties)
+        .def_rw("parameters", &Robot::parameters)
+        .def_rw("functions", &Robot::functions)
+        .def_rw("config_yaml", &Robot::config_yaml)
+
+        // --- Typed getters for properties (template get<T>) ---
+        .def("get_int", [](Robot& self, const std::string& key) { return self.get<int>(key); },
+            nb::arg("key"), "Get property value as int")
+        .def("get_double", [](Robot& self, const std::string& key) { return self.get<double>(key); },
+            nb::arg("key"), "Get property value as double")
+        .def("get_string", [](Robot& self, const std::string& key) { return self.get<std::string>(key); },
+            nb::arg("key"), "Get property value as string")
+        .def("get_bool", [](Robot& self, const std::string& key) { return self.get<bool>(key); },
+            nb::arg("key"), "Get property value as bool")
+        .def("get_vector_int", [](Robot& self, const std::string& key) { return self.get<std::vector<int>>(key); },
+            nb::arg("key"), "Get property value as vector<int>")
+        .def("get_vector_double", [](Robot& self, const std::string& key) { return self.get<std::vector<double>>(key); },
+            nb::arg("key"), "Get property value as vector<double>")
+        .def("get_vector_string", [](Robot& self, const std::string& key) { return self.get<std::vector<std::string>>(key); },
+            nb::arg("key"), "Get property value as vector<string>")
+        .def("get_vector_short", [](Robot& self, const std::string& key) { return self.get<std::vector<short>>(key); },
+            nb::arg("key"), "Get property value as vector<short>")
+
+        // --- Symbolic model access ---
+        .def("get_model", &Robot::get_model,
+            nb::arg("key"), nb::arg("explicit_args") = std::vector<casadi::SX>{},
+            "Get symbolic expression (casadi.SX) for a parameter or function")
+
+        // --- Numeric evaluation ---
+        .def("get_value", static_cast<casadi::DM (Robot::*)(std::string, std::vector<casadi::DM>)>(&Robot::get),
+            nb::arg("key"), nb::arg("explicit_args") = std::vector<casadi::DM>{},
+            "Evaluate a parameter or function numerically (returns casadi.DM)")
+
+        // --- Set parameter value ---
+        .def("set", &Robot::set, nb::arg("name"), nb::arg("value"),
+            "Set a parameter's numeric value")
+
+        // --- Typed add_property ---
+        .def("add_property_int", [](Robot& self, const std::string& name, int val, const std::string& descr, bool overwrite) {
+            return self.add_property<int>(name, val, "int", descr, overwrite);
+        }, nb::arg("name"), nb::arg("value"), nb::arg("descr") = "", nb::arg("overwrite") = true)
+        .def("add_property_double", [](Robot& self, const std::string& name, double val, const std::string& descr, bool overwrite) {
+            return self.add_property<double>(name, val, "double", descr, overwrite);
+        }, nb::arg("name"), nb::arg("value"), nb::arg("descr") = "", nb::arg("overwrite") = true)
+        .def("add_property_string", [](Robot& self, const std::string& name, const std::string& val, const std::string& descr, bool overwrite) {
+            return self.add_property<std::string>(name, val, "string", descr, overwrite);
+        }, nb::arg("name"), nb::arg("value"), nb::arg("descr") = "", nb::arg("overwrite") = true)
+        .def("add_property_bool", [](Robot& self, const std::string& name, bool val, const std::string& descr, bool overwrite) {
+            return self.add_property<bool>(name, val, "bool", descr, overwrite);
+        }, nb::arg("name"), nb::arg("value"), nb::arg("descr") = "", nb::arg("overwrite") = true)
+        .def("add_property_vector_int", [](Robot& self, const std::string& name, const std::vector<int>& val, const std::string& descr, bool overwrite) {
+            return self.add_property<std::vector<int>>(name, val, "vector<int>", descr, overwrite);
+        }, nb::arg("name"), nb::arg("value"), nb::arg("descr") = "", nb::arg("overwrite") = true)
+        .def("add_property_vector_double", [](Robot& self, const std::string& name, const std::vector<double>& val, const std::string& descr, bool overwrite) {
+            return self.add_property<std::vector<double>>(name, val, "vector<double>", descr, overwrite);
+        }, nb::arg("name"), nb::arg("value"), nb::arg("descr") = "", nb::arg("overwrite") = true)
+        .def("add_property_vector_string", [](Robot& self, const std::string& name, const std::vector<std::string>& val, const std::string& descr, bool overwrite) {
+            return self.add_property<std::vector<std::string>>(name, val, "vector<string>", descr, overwrite);
+        }, nb::arg("name"), nb::arg("value"), nb::arg("descr") = "", nb::arg("overwrite") = true)
+
+        // --- Variable & Parameter ---
+        .def("add_variable", &Robot::add_variable,
+            nb::arg("name"), nb::arg("symb"), nb::arg("num"), nb::arg("is_symbolic") = std::vector<short>{1},
+            nb::arg("descr") = "", nb::arg("overwrite") = true)
+        .def("add_parameter", &Robot::add_parameter,
+            nb::arg("name"), nb::arg("symb"), nb::arg("num"), nb::arg("is_symbolic") = std::vector<short>{0},
+            nb::arg("descr") = "", nb::arg("overwrite") = true)
+
+        // --- Function ---
+        .def("add_function", &Robot::add_function,
+            nb::arg("name"), nb::arg("expr"), nb::arg("args"), nb::arg("descr") = "",
+            nb::arg("explicit_args") = std::vector<FunArg>{}, nb::arg("overwrite") = true,
+            "Add a symbolic function to the robot model")
+
+        // --- I/O ---
+        .def("load_par", &Robot::load_par,
+            nb::arg("par_file"), nb::arg("par_list") = std::vector<std::string>{})
+        .def("save_par", &Robot::save_par,
+            nb::arg("par_file"), nb::arg("par_list") = std::vector<std::string>{})
+        .def("save_conf", &Robot::save_conf, nb::arg("conf_file"))
+
+        // --- Bulk accessors ---
+        .def("get_properties", &Robot::get_properties,
+            nb::arg("prop_list") = std::vector<std::string>{})
+        .def("get_parameters", &Robot::get_parameters,
+            nb::arg("par_list") = std::vector<std::string>{})
+        .def("get_functions", &Robot::get_functions,
+            nb::arg("fun_list") = std::vector<std::string>{})
+    ;
+
+    // =======================================================================
+    // PluginManager
+    // =======================================================================
+    nb::class_<PluginManager>(m, "PluginManager")
+        .def(nb::init<>())
+        .def("set_verbose", &PluginManager::set_verbose, nb::arg("verbose"))
+        .def("print_available_plugins", &PluginManager::print_available_plugins,
+            nb::arg("verbose") = false)
+        .def("configure_pipeline",
+            static_cast<void (PluginManager::*)(const std::string&, int)>(&PluginManager::configure_pipeline),
+            nb::arg("config_path"), nb::arg("no_generation") = 0,
+            "Configure pipeline from a YAML file path")
+        .def("execute", &PluginManager::execute,
+            nb::arg("robot_name") = "robot",
+            "Execute the pipeline and return the Robot")
+    ;
+
+    // =======================================================================
+    // Utility functions
+    // =======================================================================
+    m.def("hat", &thunder_ns::hat, nb::arg("v"), "Skew-symmetric matrix from 3-vector");
+    m.def("vect", &thunder_ns::vect, nb::arg("S"), "Extract vector from skew-symmetric matrix");
+    m.def("R_x", &thunder_ns::R_x, nb::arg("angle"), "Rotation matrix about X axis");
+    m.def("R_y", &thunder_ns::R_y, nb::arg("angle"), "Rotation matrix about Y axis");
+    m.def("R_z", &thunder_ns::R_z, nb::arg("angle"), "Rotation matrix about Z axis");
+    m.def("R_aa", &thunder_ns::R_aa, nb::arg("axis"), nb::arg("angle"), "Rotation matrix from axis-angle");
+    m.def("get_transform_rpy", &thunder_ns::get_transform_rpy, nb::arg("frame_rpy"),
+        "Homogeneous transform from [x,y,z,r,p,y] vector");
+    m.def("get_euler_rpy", &thunder_ns::get_euler_rpy, nb::arg("T"),
+        "Extract RPY Euler angles from homogeneous transform");
+
+    // =======================================================================
+    // Internal: _wrap_robot — used by C++ proxy plugins to pass Robot to Python
+    // =======================================================================
+    m.def("_wrap_robot", [](nb::capsule capsule) -> std::shared_ptr<Robot> {
+        auto* sp = static_cast<std::shared_ptr<Robot>*>(
+            PyCapsule_GetPointer(capsule.ptr(), "thunder_robot_ptr"));
+        if (!sp) {
+            throw std::runtime_error("Invalid robot capsule");
+        }
+        return *sp;
+    }, nb::arg("capsule"),
+       "Internal: reconstruct a Robot shared_ptr from a PyCapsule (used by C++ proxy plugins)");
+}

--- a/src/thunder/python/casadi_casters.h
+++ b/src/thunder/python/casadi_casters.h
@@ -1,0 +1,165 @@
+#ifndef THUNDER_CASADI_CASTERS_H
+#define THUNDER_CASADI_CASTERS_H
+
+// CasADi SWIG <-> nanobind type bridge
+// Uses the swigbind11 pointer-extraction technique adapted for:
+//   1. nanobind (instead of pybind11)
+//   2. value types (instead of shared_ptr)
+//
+// CasADi Python objects are SWIG-wrapped. This caster extracts the C++ pointer
+// from the SwigPyObject and copy-constructs the value type, and vice versa.
+
+#include <nanobind/nanobind.h>
+#include <casadi/casadi.hpp>
+
+// SWIG runtime header — provides SwigPyObject, SWIG_TypeQuery, SWIG_NewPointerObj
+#include "swigpyrun.h"
+
+namespace nb = nanobind;
+
+namespace thunder_py {
+
+// ---------------------------------------------------------------------------
+// Helper: extract C++ pointer from a SWIG-wrapped Python object
+// ---------------------------------------------------------------------------
+template <typename T>
+T* extract_swig_ptr(nb::handle obj) {
+    // SWIG proxy objects have a .this attribute holding the SwigPyObject
+    PyObject* this_attr = PyObject_GetAttrString(obj.ptr(), "this");
+    if (!this_attr) {
+        PyErr_Clear();
+        throw nb::type_error("Expected a SWIG-wrapped object (no .this attribute)");
+    }
+
+    SwigPyObject* swig_obj = reinterpret_cast<SwigPyObject*>(this_attr);
+    T* ptr = reinterpret_cast<T*>(swig_obj->ptr);
+    Py_DECREF(this_attr);
+
+    if (!ptr) {
+        throw nb::type_error("SWIG object contains a null pointer");
+    }
+    return ptr;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: wrap a C++ object as a SWIG Python object
+// ---------------------------------------------------------------------------
+template <typename T>
+nb::object create_swig_object(const T& value, const char* swig_type_name, const char* swig_module_name) {
+    // Ensure the SWIG module is imported so type info is registered
+    PyObject* mod = PyImport_ImportModule(swig_module_name);
+    if (!mod) {
+        throw nb::type_error("Failed to import SWIG module for type creation");
+    }
+    Py_DECREF(mod);
+
+    swig_type_info* info = SWIG_TypeQuery(swig_type_name);
+    if (!info) {
+        std::string msg = std::string("SWIG type info not found for: ") + swig_type_name;
+        throw nb::type_error(msg.c_str());
+    }
+
+    // Heap-allocate a copy; SWIG_POINTER_OWN transfers ownership to Python
+    T* heap_copy = new T(value);
+    PyObject* py_obj = SWIG_NewPointerObj(heap_copy, info, SWIG_POINTER_OWN);
+    if (!py_obj) {
+        delete heap_copy;
+        throw nb::type_error("Failed to create SWIG Python object");
+    }
+
+    return nb::steal(py_obj);
+}
+
+} // namespace thunder_py
+
+
+// ===========================================================================
+// nanobind type casters for CasADi types
+// ===========================================================================
+
+namespace nanobind { namespace detail {
+
+// ---------------------------------------------------------------------------
+// casadi::SX
+// ---------------------------------------------------------------------------
+template <>
+struct type_caster<casadi::SX> {
+    NB_TYPE_CASTER(casadi::SX, const_name("casadi.SX"))
+
+    bool from_python(handle src, uint8_t, cleanup_list*) noexcept {
+        try {
+            casadi::SX* ptr = thunder_py::extract_swig_ptr<casadi::SX>(src);
+            value = *ptr;
+            return true;
+        } catch (...) {
+            return false;
+        }
+    }
+
+    static handle from_cpp(const casadi::SX& src, rv_policy, cleanup_list*) noexcept {
+        try {
+            nb::object obj = thunder_py::create_swig_object(src, "casadi::SX *", "casadi.casadi");
+            return obj.release();
+        } catch (...) {
+            return handle();
+        }
+    }
+};
+
+// ---------------------------------------------------------------------------
+// casadi::DM
+// ---------------------------------------------------------------------------
+template <>
+struct type_caster<casadi::DM> {
+    NB_TYPE_CASTER(casadi::DM, const_name("casadi.DM"))
+
+    bool from_python(handle src, uint8_t, cleanup_list*) noexcept {
+        try {
+            casadi::DM* ptr = thunder_py::extract_swig_ptr<casadi::DM>(src);
+            value = *ptr;
+            return true;
+        } catch (...) {
+            return false;
+        }
+    }
+
+    static handle from_cpp(const casadi::DM& src, rv_policy, cleanup_list*) noexcept {
+        try {
+            nb::object obj = thunder_py::create_swig_object(src, "casadi::DM *", "casadi.casadi");
+            return obj.release();
+        } catch (...) {
+            return handle();
+        }
+    }
+};
+
+// ---------------------------------------------------------------------------
+// casadi::Function
+// ---------------------------------------------------------------------------
+template <>
+struct type_caster<casadi::Function> {
+    NB_TYPE_CASTER(casadi::Function, const_name("casadi.Function"))
+
+    bool from_python(handle src, uint8_t, cleanup_list*) noexcept {
+        try {
+            casadi::Function* ptr = thunder_py::extract_swig_ptr<casadi::Function>(src);
+            value = *ptr;
+            return true;
+        } catch (...) {
+            return false;
+        }
+    }
+
+    static handle from_cpp(const casadi::Function& src, rv_policy, cleanup_list*) noexcept {
+        try {
+            nb::object obj = thunder_py::create_swig_object(src, "casadi::Function *", "casadi.casadi");
+            return obj.release();
+        } catch (...) {
+            return handle();
+        }
+    }
+};
+
+}} // namespace nanobind::detail
+
+#endif // THUNDER_CASADI_CASTERS_H

--- a/src/thunder/python/yaml_casters.h
+++ b/src/thunder/python/yaml_casters.h
@@ -1,0 +1,153 @@
+#ifndef THUNDER_YAML_CASTERS_H
+#define THUNDER_YAML_CASTERS_H
+
+// Bidirectional conversion between YAML::Node and Python dict/list/scalar.
+// Used to pass YAML config to Python plugins as native Python dicts.
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
+#include <yaml-cpp/yaml.h>
+
+namespace nb = nanobind;
+
+namespace thunder_py {
+
+// ---------------------------------------------------------------------------
+// YAML::Node -> Python object (recursive)
+// ---------------------------------------------------------------------------
+inline nb::object yaml_to_python(const YAML::Node& node) {
+    if (!node.IsDefined() || node.IsNull()) {
+        return nb::none();
+    }
+
+    if (node.IsScalar()) {
+        const std::string& s = node.Scalar();
+
+        // Try bool
+        if (s == "true" || s == "True" || s == "TRUE") return nb::bool_(true);
+        if (s == "false" || s == "False" || s == "FALSE") return nb::bool_(false);
+
+        // Try integer
+        try {
+            size_t pos;
+            long long iv = std::stoll(s, &pos);
+            if (pos == s.size()) return nb::int_(iv);
+        } catch (...) {}
+
+        // Try double
+        try {
+            size_t pos;
+            double dv = std::stod(s, &pos);
+            if (pos == s.size()) return nb::float_(dv);
+        } catch (...) {}
+
+        // Fallback to string
+        return nb::cast(s);
+    }
+
+    if (node.IsSequence()) {
+        nb::list lst;
+        for (auto it = node.begin(); it != node.end(); ++it) {
+            lst.append(yaml_to_python(*it));
+        }
+        return lst;
+    }
+
+    if (node.IsMap()) {
+        nb::dict d;
+        for (auto it = node.begin(); it != node.end(); ++it) {
+            nb::object key = yaml_to_python(it->first);
+            nb::object val = yaml_to_python(it->second);
+            d[key] = val;
+        }
+        return d;
+    }
+
+    return nb::none();
+}
+
+// ---------------------------------------------------------------------------
+// Python object -> YAML::Node (recursive)
+// ---------------------------------------------------------------------------
+inline YAML::Node python_to_yaml(nb::handle obj) {
+    YAML::Node node;
+
+    if (obj.is_none()) {
+        return node; // Null node
+    }
+
+    // Check bool before int (bool is subclass of int in Python)
+    if (nb::isinstance<nb::bool_>(obj)) {
+        node = nb::cast<bool>(obj);
+        return node;
+    }
+
+    if (nb::isinstance<nb::int_>(obj)) {
+        node = nb::cast<long long>(obj);
+        return node;
+    }
+
+    if (nb::isinstance<nb::float_>(obj)) {
+        node = nb::cast<double>(obj);
+        return node;
+    }
+
+    if (nb::isinstance<nb::str>(obj)) {
+        node = nb::cast<std::string>(obj);
+        return node;
+    }
+
+    if (nb::isinstance<nb::list>(obj) || nb::isinstance<nb::tuple>(obj)) {
+        for (nb::handle item : obj) {
+            node.push_back(python_to_yaml(item));
+        }
+        return node;
+    }
+
+    if (nb::isinstance<nb::dict>(obj)) {
+        nb::dict d = nb::borrow<nb::dict>(obj);
+        for (auto [key, val] : d) {
+            std::string key_str = nb::cast<std::string>(nb::str(key));
+            node[key_str] = python_to_yaml(val);
+        }
+        return node;
+    }
+
+    // Fallback: convert to string via Python str()
+    node = nb::cast<std::string>(nb::str(obj));
+    return node;
+}
+
+} // namespace thunder_py
+
+// ===========================================================================
+// nanobind type caster for YAML::Node
+// ===========================================================================
+namespace nanobind { namespace detail {
+
+template <>
+struct type_caster<YAML::Node> {
+    NB_TYPE_CASTER(YAML::Node, const_name("dict"))
+
+    bool from_python(handle src, uint8_t, cleanup_list*) noexcept {
+        try {
+            value = thunder_py::python_to_yaml(src);
+            return true;
+        } catch (...) {
+            return false;
+        }
+    }
+
+    static handle from_cpp(const YAML::Node& src, rv_policy, cleanup_list*) noexcept {
+        try {
+            nb::object obj = thunder_py::yaml_to_python(src);
+            return obj.release();
+        } catch (...) {
+            return handle();
+        }
+    }
+};
+
+}} // namespace nanobind::detail
+
+#endif // THUNDER_YAML_CASTERS_H

--- a/src/thunder/robots/debug/RRR_py.yaml
+++ b/src/thunder/robots/debug/RRR_py.yaml
@@ -1,6 +1,6 @@
 pipeline:
   loaders:    ["kin_loader", "dyn_loader"]
-  builders:   ["kin_builder", "dyn_builder", "py:my_py_builder.MyCosBuilder"]
+  builders:   ["kin_builder", "dyn_builder", "py.my_py_builder.MyCosBuilder"]
   generators: []  # no code gen — just test the Python builder
 
 version: 1.0
@@ -11,7 +11,7 @@ PI_2_neg: &PI_2_neg  -1.5707963267948966
 
 ############################################
 # Python plugin config (key = plugin name from pipeline)
-"py:my_py_builder.MyCosBuilder":
+"py.my_py_builder.MyCosBuilder":
   function_name: "cos_q"
 
 ############################################

--- a/src/thunder/robots/debug/RRR_py.yaml
+++ b/src/thunder/robots/debug/RRR_py.yaml
@@ -1,0 +1,125 @@
+pipeline:
+  loaders:    ["kin_loader", "dyn_loader"]
+  builders:   ["kin_builder", "dyn_builder", "py:my_py_builder.MyCosBuilder"]
+  generators: []  # no code gen — just test the Python builder
+
+version: 1.0
+
+# --- Constants --- #
+PI_2: &PI_2           1.5707963267948966
+PI_2_neg: &PI_2_neg  -1.5707963267948966
+
+############################################
+# Python plugin config (key = plugin name from pipeline)
+"py:my_py_builder.MyCosBuilder":
+  function_name: "cos_q"
+
+############################################
+robot_generator:
+  gen_python:   false
+  gen_casadi:   true
+  gen_robot:    true
+  copy_gen:     true
+
+############################################
+kin_loader:
+
+  # --- Hyperparameters --- #
+  num_joints: 3
+
+  # joint types: 'R': rotoidal, 'P': prismatic
+  joints_type: ['R', 'R', 'R']
+
+  # joint positions (xyz-rpy)
+  kinematics:
+    joint1:
+      joint_type: R
+      symb: [0,0,0,0,0,0]
+      xyz: [0,0,1]
+      rpy: [0,0,0]
+    joint2:
+      joint_type: R
+      axis: [0,0,1]
+      symb: [0,0,0,0,0,0]
+      xyzrpy: [1,0,0, *PI_2,0,0]
+    joint3:
+      joint_type: R
+      symb: [0,0,0,0,0,0]
+      xyz: [1,0,0]
+      ypr: [0,0,0]
+
+  # world to link_0
+  Base_to_L0:
+    symb: [0,0,0, 0,0,0]
+    xyz: [0, 0, 0]
+    ypr: [0, 0, 0]
+
+  # Link_n to EE
+  Ln_to_EE:
+    symb: [0,0,0, 0,0,0]
+    xyz: [1, 0, 0]
+    ypr: [0, 0, *PI_2_neg]
+
+############################################
+dyn_loader:
+
+  # link friction
+  Dl_order: 2
+
+  # gravity vector
+  gravity:
+    symb: [0,0,0]
+    value: [0, 0, -9.81]
+
+  # inertial parameters expressed w.r.t. kinematic frames
+  dynamics:
+    link1:
+      inertial:
+        symb: [1,1,1,1,1,1,1,1,1,1]
+        mass: 1.0
+        CoM_x: 0.5
+        CoM_y: 0.0
+        CoM_z: 0.0
+        Ixx: 0.01
+        Ixy: 0.0
+        Ixz: 0.0
+        Iyy: 0.3
+        Iyz: 0.0
+        Izz: 0.3
+      friction:
+        symb: [0,0]
+        Dl: [0.1, 0.01]
+
+    link2:
+      inertial:
+        symb: [1,1,1,1,1,1,1,1,1,1]
+        mass: 1.0
+        CoM_x: 0.5
+        CoM_y: 0.0
+        CoM_z: 0.0
+        Ixx: 0.01
+        Ixy: 0.0
+        Ixz: 0.0
+        Iyy: 0.3
+        Iyz: 0.0
+        Izz: 0.3
+      friction:
+        symb: [0,0]
+        Dl: [0.1, 0.01]
+
+    link3:
+      inertial:
+        symb: [1,1,1,1,1,1,1,1,1,1]
+        mass: 1.0
+        CoM_x: 0.5
+        CoM_y: 0.0
+        CoM_z: 0.0
+        Ixx: 0.01
+        Ixy: 0.0
+        Ixz: 0.0
+        Iyy: 0.3
+        Iyz: 0.0
+        Izz: 0.3
+      friction:
+        symb: [0,0]
+        Dl: [0.1, 0.01]

--- a/src/thunder/robots/debug/my_py_builder.py
+++ b/src/thunder/robots/debug/my_py_builder.py
@@ -1,0 +1,33 @@
+"""
+Example Python builder plugin for Thunder.
+
+This plugin adds a custom function (cosine of joint angles) to the robot model.
+It demonstrates how to:
+  - Inherit from BaseBuilder (mandatory)
+  - Optionally define a pydantic ConfigModel for config validation
+  - Access robot properties and symbolic variables
+  - Use CasADi Python API for symbolic computation
+  - Add new functions to the Robot from Python
+"""
+import casadi
+from pydantic import BaseModel
+from thunder_core.plugins import BaseBuilder
+
+
+class MyCosBuilder(BaseBuilder):
+    """Adds cos(q) as a new function to the robot."""
+
+    class ConfigModel(BaseModel):
+        function_name: str = "cos_q"
+
+    def build(self, robot):
+        num_joints = robot.get_int("numJoints")
+        print(f"  [MyCosBuilder] Robot '{robot.robotName}' has {num_joints} joints")
+
+        q = robot.get_model("q")
+        print(f"  [MyCosBuilder] q = {q}")
+
+        expr = casadi.cos(q)
+
+        robot.add_function(self.config.function_name, expr, ["q"], "Cosine of joint angles")
+        print(f"  [MyCosBuilder] Added function '{self.config.function_name}'")

--- a/src/thunder/src/plugins/python/py_plugin_proxy.cpp
+++ b/src/thunder/src/plugins/python/py_plugin_proxy.cpp
@@ -14,15 +14,15 @@ namespace thunder_ns {
 // =========================================================================
 
 std::tuple<std::string, std::string> parse_py_plugin_name(const std::string& name) {
-    // Input: "PY.module.path.ClassName"
-    // Strip "PY." prefix
+    // Input: "py.module.path.ClassName"
+    // Strip "py." prefix
     std::string qualified = name.substr(3);
 
     // Split at last '.' to separate module from class
     auto last_dot = qualified.rfind('.');
     if (last_dot == std::string::npos) {
         throw std::runtime_error(
-            "Invalid Python plugin name '" + name + "': expected 'PY.module.ClassName'");
+            "Invalid Python plugin name '" + name + "': expected 'py.module.ClassName'");
     }
 
     return {qualified.substr(0, last_dot), qualified.substr(last_dot + 1)};
@@ -214,7 +214,7 @@ static void call_with_robot(PyObject* py_instance, const char* method_name,
 // =========================================================================
 
 PyLoaderProxy::PyLoaderProxy(const std::string& module_name, const std::string& class_name)
-    : BaseLoader("PY." + module_name + "." + class_name,
+    : BaseLoader("py." + module_name + "." + class_name,
                  "Python loader: " + module_name + "." + class_name),
       module_name_(module_name), class_name_(class_name) {}
 
@@ -250,7 +250,7 @@ std::shared_ptr<Robot> PyLoaderProxy::load(std::shared_ptr<Robot> robot) {
 // =========================================================================
 
 PyBuilderProxy::PyBuilderProxy(const std::string& module_name, const std::string& class_name)
-    : BaseBuilder("PY." + module_name + "." + class_name,
+    : BaseBuilder("py." + module_name + "." + class_name,
                   "Python builder: " + module_name + "." + class_name),
       module_name_(module_name), class_name_(class_name) {}
 
@@ -284,7 +284,7 @@ void PyBuilderProxy::build(std::shared_ptr<Robot> robot) {
 // =========================================================================
 
 PyGeneratorProxy::PyGeneratorProxy(const std::string& module_name, const std::string& class_name)
-    : BaseGenerator("PY." + module_name + "." + class_name,
+    : BaseGenerator("py." + module_name + "." + class_name,
                     "Python generator: " + module_name + "." + class_name),
       module_name_(module_name), class_name_(class_name) {}
 

--- a/src/thunder/src/plugins/python/py_plugin_proxy.cpp
+++ b/src/thunder/src/plugins/python/py_plugin_proxy.cpp
@@ -1,0 +1,318 @@
+#ifdef THUNDER_PYTHON_PLUGINS
+
+#include "plugins/python/py_plugin_proxy.h"
+
+#include <Python.h>
+#include <filesystem>
+#include <sstream>
+#include <stdexcept>
+
+namespace thunder_ns {
+
+// =========================================================================
+// Helpers
+// =========================================================================
+
+std::tuple<std::string, std::string> parse_py_plugin_name(const std::string& name) {
+    // Input: "py:module.path.ClassName"
+    // Strip "py:" prefix
+    std::string qualified = name.substr(3);
+
+    // Split at last '.' to separate module from class
+    auto last_dot = qualified.rfind('.');
+    if (last_dot == std::string::npos) {
+        throw std::runtime_error(
+            "Invalid Python plugin name '" + name + "': expected 'py:module.ClassName'");
+    }
+
+    return {qualified.substr(0, last_dot), qualified.substr(last_dot + 1)};
+}
+
+/// Fetch and format the current Python exception as a string.
+/// Clears the Python error indicator.
+static std::string fetch_python_error() {
+    if (!PyErr_Occurred()) return "(no Python error set)";
+
+    PyObject *ptype, *pvalue, *ptraceback;
+    PyErr_Fetch(&ptype, &pvalue, &ptraceback);
+    PyErr_NormalizeException(&ptype, &pvalue, &ptraceback);
+
+    std::string msg = "Python error";
+    if (pvalue) {
+        PyObject* str_obj = PyObject_Str(pvalue);
+        if (str_obj) {
+            const char* s = PyUnicode_AsUTF8(str_obj);
+            if (s) msg = s;
+            Py_DECREF(str_obj);
+        }
+    }
+
+    // Try to get traceback
+    if (ptraceback) {
+        PyObject* tb_module = PyImport_ImportModule("traceback");
+        if (tb_module) {
+            PyObject* format_func = PyObject_GetAttrString(tb_module, "format_exception");
+            if (format_func) {
+                PyObject* result = PyObject_CallFunctionObjArgs(
+                    format_func, ptype, pvalue, ptraceback, NULL);
+                if (result) {
+                    PyObject* joined = PyUnicode_Join(PyUnicode_FromString(""), result);
+                    if (joined) {
+                        const char* s = PyUnicode_AsUTF8(joined);
+                        if (s) msg = s;
+                        Py_DECREF(joined);
+                    }
+                    Py_DECREF(result);
+                }
+                Py_DECREF(format_func);
+            }
+            Py_DECREF(tb_module);
+        }
+    }
+
+    Py_XDECREF(ptype);
+    Py_XDECREF(pvalue);
+    Py_XDECREF(ptraceback);
+
+    return msg;
+}
+
+/// Import a Python module and instantiate a class from it.
+/// Returns a new reference to the instance (caller must DECREF).
+static PyObject* import_and_instantiate(const std::string& module_name, const std::string& class_name) {
+    PythonInterpreter::instance().ensure_initialized();
+
+    PyObject* py_module = PyImport_ImportModule(module_name.c_str());
+    if (!py_module) {
+        std::string err = fetch_python_error();
+        throw std::runtime_error("Failed to import Python module '" + module_name + "': " + err);
+    }
+
+    PyObject* py_class = PyObject_GetAttrString(py_module, class_name.c_str());
+    Py_DECREF(py_module);
+    if (!py_class) {
+        std::string err = fetch_python_error();
+        throw std::runtime_error(
+            "Class '" + class_name + "' not found in module '" + module_name + "': " + err);
+    }
+
+    // Instantiate: py_instance = py_class()
+    PyObject* py_instance = PyObject_CallObject(py_class, NULL);
+    Py_DECREF(py_class);
+    if (!py_instance) {
+        std::string err = fetch_python_error();
+        throw std::runtime_error(
+            "Failed to instantiate '" + module_name + "." + class_name + "': " + err);
+    }
+
+    return py_instance;
+}
+
+/// Call py_instance.configure(config_dict) where config is a YAML::Node
+/// converted to a Python dict via the yaml_to_python helper.
+static void call_configure(PyObject* py_instance, const YAML::Node& config) {
+    // Import thunder_py yaml helper (compiled into thunder_core module)
+    // Instead, we do the conversion manually using the Python yaml module or
+    // by converting YAML -> string -> Python dict via yaml.safe_load
+    // This avoids depending on the nanobind module at this point.
+
+    // Convert YAML::Node to a YAML string, then parse in Python
+    YAML::Emitter emitter;
+    emitter << config;
+    std::string yaml_str = emitter.c_str();
+
+    // Use Python's yaml.safe_load to parse
+    PyObject* yaml_module = PyImport_ImportModule("yaml");
+    if (!yaml_module) {
+        // Fallback: pass an empty dict if PyYAML is not available
+        PyObject* empty_dict = PyDict_New();
+        PyObject* result = PyObject_CallMethod(py_instance, "configure", "(O)", empty_dict);
+        Py_XDECREF(result);
+        Py_DECREF(empty_dict);
+        return;
+    }
+
+    PyObject* py_yaml_str = PyUnicode_FromString(yaml_str.c_str());
+    PyObject* config_dict = PyObject_CallMethod(yaml_module, "safe_load", "(O)", py_yaml_str);
+    Py_DECREF(py_yaml_str);
+    Py_DECREF(yaml_module);
+
+    if (!config_dict || config_dict == Py_None) {
+        Py_XDECREF(config_dict);
+        config_dict = PyDict_New();
+    }
+
+    PyObject* result = PyObject_CallMethod(py_instance, "configure", "(O)", config_dict);
+    Py_DECREF(config_dict);
+    if (!result) {
+        std::string err = fetch_python_error();
+        throw std::runtime_error("Python plugin configure() failed: " + err);
+    }
+    Py_DECREF(result);
+}
+
+/// Call a method on the Python plugin instance, passing the Robot as a
+/// thunder_core.Robot object via nanobind capsule.
+/// This requires the thunder_core module to be importable.
+static void call_with_robot(PyObject* py_instance, const char* method_name,
+                            std::shared_ptr<Robot> robot) {
+    // Import the thunder_core._bindings module to get the Robot type
+    PyObject* tc_module = PyImport_ImportModule("thunder_core._bindings");
+    if (!tc_module) {
+        std::string err = fetch_python_error();
+        throw std::runtime_error(
+            "Failed to import thunder_core._bindings module (required for Python plugins): " + err);
+    }
+
+    // Use nanobind's internal casting to create a Python Robot wrapper.
+    // We do this by calling thunder_core._wrap_robot_ptr(capsule) — but nanobind
+    // doesn't expose that directly. Instead, we use the nanobind C API.
+    //
+    // Alternative approach: use a global function registered in thunder_core
+    // that accepts a raw pointer via capsule and returns a wrapped Robot.
+
+    // We registered a _wrap_robot helper in thunder_core._bindings for this purpose.
+    PyObject* wrap_fn = PyObject_GetAttrString(tc_module, "_wrap_robot");
+    Py_DECREF(tc_module);
+
+    if (!wrap_fn) {
+        std::string err = fetch_python_error();
+        throw std::runtime_error("thunder_core._bindings._wrap_robot not found: " + err);
+    }
+
+    // Pass the shared_ptr as a PyCapsule
+    // The capsule destructor will release the shared_ptr copy
+    auto* sp_copy = new std::shared_ptr<Robot>(robot);
+    PyObject* capsule = PyCapsule_New(sp_copy, "thunder_robot_ptr", [](PyObject* cap) {
+        auto* sp = static_cast<std::shared_ptr<Robot>*>(PyCapsule_GetPointer(cap, "thunder_robot_ptr"));
+        delete sp;
+    });
+
+    PyObject* py_robot = PyObject_CallFunctionObjArgs(wrap_fn, capsule, NULL);
+    Py_DECREF(wrap_fn);
+    Py_DECREF(capsule);
+
+    if (!py_robot) {
+        std::string err = fetch_python_error();
+        throw std::runtime_error("Failed to wrap Robot for Python: " + err);
+    }
+
+    // Call the method: py_instance.method(py_robot)
+    PyObject* result = PyObject_CallMethod(py_instance, method_name, "(O)", py_robot);
+    Py_DECREF(py_robot);
+
+    if (!result) {
+        std::string err = fetch_python_error();
+        throw std::runtime_error(
+            std::string("Python plugin ") + method_name + "() failed: " + err);
+    }
+    Py_DECREF(result);
+}
+
+// =========================================================================
+// PyLoaderProxy
+// =========================================================================
+
+PyLoaderProxy::PyLoaderProxy(const std::string& module_name, const std::string& class_name)
+    : BaseLoader("py:" + module_name + "." + class_name,
+                 "Python loader: " + module_name + "." + class_name),
+      module_name_(module_name), class_name_(class_name) {}
+
+void PyLoaderProxy::ensure_instance() {
+    if (!py_instance_) {
+        // Add the config file directory to sys.path
+        if (config_["config_path"]) {
+            std::string config_path = config_["config_path"].as<std::string>();
+            std::filesystem::path dir = std::filesystem::path(config_path).parent_path();
+            PythonInterpreter::instance().add_to_sys_path(dir.string());
+        }
+        py_instance_ = import_and_instantiate(module_name_, class_name_);
+        call_configure(py_instance_, config_);
+    }
+}
+
+std::shared_ptr<Robot> PyLoaderProxy::load(std::shared_ptr<Robot> robot) {
+    PythonInterpreter::instance().ensure_initialized();
+    PyGILState_STATE gstate = PyGILState_Ensure();
+    try {
+        ensure_instance();
+        call_with_robot(py_instance_, "load", robot);
+        PyGILState_Release(gstate);
+        return robot;
+    } catch (...) {
+        PyGILState_Release(gstate);
+        throw;
+    }
+}
+
+// =========================================================================
+// PyBuilderProxy
+// =========================================================================
+
+PyBuilderProxy::PyBuilderProxy(const std::string& module_name, const std::string& class_name)
+    : BaseBuilder("py:" + module_name + "." + class_name,
+                  "Python builder: " + module_name + "." + class_name),
+      module_name_(module_name), class_name_(class_name) {}
+
+void PyBuilderProxy::ensure_instance() {
+    if (!py_instance_) {
+        if (config_["config_path"]) {
+            std::string config_path = config_["config_path"].as<std::string>();
+            std::filesystem::path dir = std::filesystem::path(config_path).parent_path();
+            PythonInterpreter::instance().add_to_sys_path(dir.string());
+        }
+        py_instance_ = import_and_instantiate(module_name_, class_name_);
+        call_configure(py_instance_, config_);
+    }
+}
+
+void PyBuilderProxy::build(std::shared_ptr<Robot> robot) {
+    PythonInterpreter::instance().ensure_initialized();
+    PyGILState_STATE gstate = PyGILState_Ensure();
+    try {
+        ensure_instance();
+        call_with_robot(py_instance_, "build", robot);
+        PyGILState_Release(gstate);
+    } catch (...) {
+        PyGILState_Release(gstate);
+        throw;
+    }
+}
+
+// =========================================================================
+// PyGeneratorProxy
+// =========================================================================
+
+PyGeneratorProxy::PyGeneratorProxy(const std::string& module_name, const std::string& class_name)
+    : BaseGenerator("py:" + module_name + "." + class_name,
+                    "Python generator: " + module_name + "." + class_name),
+      module_name_(module_name), class_name_(class_name) {}
+
+void PyGeneratorProxy::ensure_instance() {
+    if (!py_instance_) {
+        if (config_["config_path"]) {
+            std::string config_path = config_["config_path"].as<std::string>();
+            std::filesystem::path dir = std::filesystem::path(config_path).parent_path();
+            PythonInterpreter::instance().add_to_sys_path(dir.string());
+        }
+        py_instance_ = import_and_instantiate(module_name_, class_name_);
+        call_configure(py_instance_, config_);
+    }
+}
+
+void PyGeneratorProxy::generate(const std::shared_ptr<Robot> robot) {
+    PythonInterpreter::instance().ensure_initialized();
+    PyGILState_STATE gstate = PyGILState_Ensure();
+    try {
+        ensure_instance();
+        call_with_robot(py_instance_, "generate", std::const_pointer_cast<Robot>(robot));
+        PyGILState_Release(gstate);
+    } catch (...) {
+        PyGILState_Release(gstate);
+        throw;
+    }
+}
+
+} // namespace thunder_ns
+
+#endif // THUNDER_PYTHON_PLUGINS

--- a/src/thunder/src/plugins/python/py_plugin_proxy.cpp
+++ b/src/thunder/src/plugins/python/py_plugin_proxy.cpp
@@ -14,15 +14,15 @@ namespace thunder_ns {
 // =========================================================================
 
 std::tuple<std::string, std::string> parse_py_plugin_name(const std::string& name) {
-    // Input: "py:module.path.ClassName"
-    // Strip "py:" prefix
+    // Input: "PY.module.path.ClassName"
+    // Strip "PY." prefix
     std::string qualified = name.substr(3);
 
     // Split at last '.' to separate module from class
     auto last_dot = qualified.rfind('.');
     if (last_dot == std::string::npos) {
         throw std::runtime_error(
-            "Invalid Python plugin name '" + name + "': expected 'py:module.ClassName'");
+            "Invalid Python plugin name '" + name + "': expected 'PY.module.ClassName'");
     }
 
     return {qualified.substr(0, last_dot), qualified.substr(last_dot + 1)};
@@ -214,7 +214,7 @@ static void call_with_robot(PyObject* py_instance, const char* method_name,
 // =========================================================================
 
 PyLoaderProxy::PyLoaderProxy(const std::string& module_name, const std::string& class_name)
-    : BaseLoader("py:" + module_name + "." + class_name,
+    : BaseLoader("PY." + module_name + "." + class_name,
                  "Python loader: " + module_name + "." + class_name),
       module_name_(module_name), class_name_(class_name) {}
 
@@ -250,7 +250,7 @@ std::shared_ptr<Robot> PyLoaderProxy::load(std::shared_ptr<Robot> robot) {
 // =========================================================================
 
 PyBuilderProxy::PyBuilderProxy(const std::string& module_name, const std::string& class_name)
-    : BaseBuilder("py:" + module_name + "." + class_name,
+    : BaseBuilder("PY." + module_name + "." + class_name,
                   "Python builder: " + module_name + "." + class_name),
       module_name_(module_name), class_name_(class_name) {}
 
@@ -284,7 +284,7 @@ void PyBuilderProxy::build(std::shared_ptr<Robot> robot) {
 // =========================================================================
 
 PyGeneratorProxy::PyGeneratorProxy(const std::string& module_name, const std::string& class_name)
-    : BaseGenerator("py:" + module_name + "." + class_name,
+    : BaseGenerator("PY." + module_name + "." + class_name,
                     "Python generator: " + module_name + "." + class_name),
       module_name_(module_name), class_name_(class_name) {}
 


### PR DESCRIPTION
This PR adds support for writing Thunder plugins in Python, introduces the `thunder_core` Python package, and updates the build system and C++ code to enable Python plugin integration via nanobind and SWIG. The changes include new documentation, Python package modules, CMake configuration, and C++/Python interop code.

**Python Plugin Support and Documentation**

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R88-R268): Adds comprehensive documentation on writing and using Python plugins, including build instructions, package structure, conventions, API usage, and examples.

**Python Package Implementation**

* [`python/thunder_core/__init__.py`](diffhunk://#diff-a766778237441f13aea969200fd56beafdd32826d8e236f14109d1ea0158ffa6R1-R62): Introduces the main `thunder_core` Python package, re-exporting C++ bindings and submodules for plugin and pipeline support.
* [`python/thunder_core/plugins.py`](diffhunk://#diff-84db4ed79a0f2303dac18a72d81119df77c212f502abe7be7c55cd97118204d1R1-R107): Implements abstract base classes (`BaseLoader`, `BaseBuilder`, `BaseGenerator`) for Python plugins, with optional pydantic-based config validation.
* [`python/thunder_core/pipeline.py`](diffhunk://#diff-6cea0daf6c101eb29c3df182e8fb2abd41bac756ef12dd3eb67fd26b346d8fffR1-R113): Adds a pipeline configuration and execution interface for running Thunder pipelines from Python code or notebooks, supporting both YAML files and Python dicts.


**Build System and C++ Integration**

* [`src/thunder/CMakeLists.txt`](diffhunk://#diff-71b713a4960e2c9b2a9ac1168230598f3ff1816b24be6fdcaa80b189c97b6a08L2-R2): Adds the `BUILD_PYTHON_PLUGINS` option (default ON), configures nanobind and SWIG for Python plugin support, sets up building and installing the `thunder_core` Python package, and ensures Python proxy plugins are included in the build. [[1]](diffhunk://#diff-71b713a4960e2c9b2a9ac1168230598f3ff1816b24be6fdcaa80b189c97b6a08L2-R2) [[2]](diffhunk://#diff-71b713a4960e2c9b2a9ac1168230598f3ff1816b24be6fdcaa80b189c97b6a08L22-R31) [[3]](diffhunk://#diff-71b713a4960e2c9b2a9ac1168230598f3ff1816b24be6fdcaa80b189c97b6a08R127-R203)
* [`src/thunder/include/plugin_manager.h`](diffhunk://#diff-ce9b05ce28245e9b57bbfff4adc408898d0a2a1122f303b0c86b5723151cc2d9R12-R15): Updates the plugin manager to recognize and instantiate Python plugins (with `PY.` prefix) using proxy classes when Python plugin support is enabled. [[1]](diffhunk://#diff-ce9b05ce28245e9b57bbfff4adc408898d0a2a1122f303b0c86b5723151cc2d9R12-R15) [[2]](diffhunk://#diff-ce9b05ce28245e9b57bbfff4adc408898d0a2a1122f303b0c86b5723151cc2d9L147-R160) [[3]](diffhunk://#diff-ce9b05ce28245e9b57bbfff4adc408898d0a2a1122f303b0c86b5723151cc2d9L157-R179) [[4]](diffhunk://#diff-ce9b05ce28245e9b57bbfff4adc408898d0a2a1122f303b0c86b5723151cc2d9L167-R198)

These changes collectively enable Python plugin support in Thunder, allowing users to write, configure, and execute plugins in Python alongside existing C++ plugins.